### PR TITLE
Add python3.5 support

### DIFF
--- a/modularsettings/settings/__init__.py
+++ b/modularsettings/settings/__init__.py
@@ -3,7 +3,7 @@ import pkgutil
 
 
 for _, module_name, _ in pkgutil.walk_packages(__path__):
-    module = __import__(module_name, globals(), locals(), [])
+    module = __import__(module_name, globals(), locals(), [], levels=1)
     for var_name, val in inspect.getmembers(module):
         if var_name.isupper():
             locals().update({var_name: val})


### PR DESCRIPTION
Specifying the `levels` option brings python3.5 support. The meaning of this argument has valuably changed from python2 -> python3 as far as that by default discovery of the modules in the current directory is not working properly.
Specifying level = 1 tells the import module that it should search in the current directory, and thus that makes the code work on python3 again.